### PR TITLE
Add paging for fetch remaining repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadiasoftwaredevelopment/create-arcadia-project",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The command line tool that is used to create project and increase productivity for Arcadia Software Development company.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Initially, the api `bitbucket.repositories.list` could only display the first 10 repositories from Bitbucket.

I have updated it to retrieve all repositories by adding a page parameter and checking if there is a next page. If there is, it will continue fetching until all repositories are retrieved.